### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 LoadingView is easy to implement Loading indicators for your views or layouts. 
 
-##Screenshots
+## Screenshots
 ![Image](https://raw.githubusercontent.com/buraktamturk/LoadingView/master/screenshots/sample.gif)
 ![Image](https://raw.githubusercontent.com/buraktamturk/LoadingView/master/screenshots/sample2.gif)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
